### PR TITLE
tdd: add failing test, make it pass, and polish README

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+        "name": "Ubuntu",
+        "image": "mcr.microsoft.com/devcontainers/base:noble",
+        "features": {
+                "ghcr.io/jungaretti/features/make:1": {},
+                "ghcr.io/michidk/devcontainers-features/typos:1": {}
+        }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+test:
+	typos

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Please create a column-based To Do application, similar to a JIRA Kanban or Trel
 * Each todo should exist on a "card" and cards should be able to be dragged and dropped between columns.
 * Each card should have a Title and Description
 * Users should be able to create and delete cards as necessary
-* Uses should be able to create and delete columsn as necessary
+* Uses should be able to create and delete columns as necessary
 * Each card should have a direct link to it, so that going to "myapp.com/todo/<cardID>" displays the card title and description
 
 ### Design Considerations
@@ -28,7 +28,7 @@ Please create a column-based To Do application, similar to a JIRA Kanban or Trel
 
 
 ### Process
-Once complete, create a Pull Request (PR) against this repository so we can review your submission. After reivew, if we decide to move forward with your interview process, we will sit down and review your code, so please be prepared to talk about design decisions, trade-offs, future improvements, etc.
+Once complete, create a Pull Request (PR) against this repository so we can review your submission. After review, if we decide to move forward with your interview process, we will sit down and review your code, so please be prepared to talk about design decisions, trade-offs, future improvements, etc.
 
 
 If you have any questions or need clarification please send your recruiter a message.

--- a/README.md
+++ b/README.md
@@ -20,17 +20,80 @@ Please create a column-based To Do application, similar to a JIRA Kanban or Trel
 * Because there's no backend, feel free to use whatever storage you think is best (browser state, etc.)
 * You have full design and UI creativity -- we want to see your creativity alongside your technical ability!
 
-### Technical
-* Please do not use any AI code tools like Copilot, ChatGPT, Cursor, Claude, or other LLMs. We want to see how YOU write code, not how an LLM writes code.
-* Use whatever framework you think is best for the application -- or no framework at all.
-* No need for 100% test coverage, but please at least include a few tests for us to review.
-* We should be able to get your application up and running without a lot of work, so please include any scripts, dependency lists, etc. that are necessary to build and/or run the app. Makefiles, Dockerfiles, etc. are encouraged.
+# Frontend Take Home Project
 
+This project evaluates your frontend skills and approach to building maintainable, testable applications. We want to see how you design, implement, and iterate—using Test-Driven Development (TDD) as the primary workflow.
 
-### Process
-Once complete, create a Pull Request (PR) against this repository so we can review your submission. After review, if we decide to move forward with your interview process, we will sit down and review your code, so please be prepared to talk about design decisions, trade-offs, future improvements, etc.
+IMPORTANT: We expect work to follow TDD. That means: write tests first, make them fail, implement the smallest change to make them pass, then refactor. Tests are not optional—show us your process through test commits and clear test suites.
 
+## Brief
+Create a column-based To Do application (like a Kanban board) to be viewed and interacted with in a browser. When finished, open a Pull Request (PR) against this repo for review.
 
-If you have any questions or need clarification please send your recruiter a message.
+Please don't spend excessive time—we're evaluating your thinking and process as much as the final product.
 
-Thanks, and happy coding!
+## TDD Expectations (what we're looking for)
+- Write tests before implementing features. Use small, focused tests that document intended behavior.
+- Include tests that fail initially and then pass after your implementation—this demonstrates TDD.
+- Provide at least one test for each core feature (examples below).
+- Keep tests fast and deterministic. Prefer unit tests for logic and small integration tests for component behavior.
+- Add meaningful commit messages that show the test -> implementation -> refactor cycle when possible.
+
+Contract (simple)
+- Inputs: Browser interactions / JSON fixtures for todos and columns
+- Outputs: UI state, data persistence (browser storage), and router links
+- Error modes: invalid input, empty titles/descriptions, drag/drop edge-cases
+
+Edge cases we expect tests or thought about
+- Creating a card with empty or very long title/description
+- Dragging a card to an empty column or to the same column
+- Deleting a column that contains cards (and deciding what happens to the cards)
+- Direct link to a card that doesn't exist
+
+## Feature Requirements
+- App defaults to 3 columns: To Do, Doing, Done.
+- Todo items are displayed on cards; cards can be dragged and dropped between columns.
+- Each card has a Title and Description.
+- Users can create and delete cards.
+- Users can create and delete columns.
+- Each card has a direct link (e.g. `/todo/<cardID>`) that displays that card's title and description.
+
+## Design Considerations
+- No backend is required—use browser state or any client-side storage you prefer (localStorage, indexedDB, in-memory, etc.).
+- We want to see thoughtful UI/UX decisions. Design is part of the evaluation.
+
+## Technical Notes
+- Do not use AI code generation tools (Copilot, ChatGPT, Claude, etc.). We want to see your code.
+- Use any framework (React, Vue, Svelte, Solid, or none). Choose what lets you show your best work.
+- Tests are required and are evidence of your TDD workflow. We don't require 100% coverage, but include several meaningful tests.
+
+Quality gates we suggest you cover in your PR (helps reviewers):
+- Build succeeds (include scripts to install and run),
+- Lint/type checks (if applicable),
+- Unit tests and at least one small integration test demonstrating core UI behavior,
+- Short README instructions to run the app and the tests.
+
+## How to show your TDD workflow in your submission
+- Make small commits that show tests being added first and then implementation.
+- Include a README section (or commit notes) describing the testing strategy and what each test verifies.
+- If you used a particular testing library (Jest, Vitest, Testing Library, Cypress, Playwright, etc.), list it and show how to run tests.
+
+## Example commands (add the corresponding scripts to your project)
+These are example commands—adapt them to your project's tools and package manager.
+
+```bash
+# install deps (example)
+npm install
+
+# run the app (example)
+npm start
+
+# run tests (example)
+npm test
+```
+
+## Process
+When complete, open a PR against this repository. Be prepared to talk through your design decisions, testing approach, trade-offs, and potential next steps.
+
+If you have questions, contact your recruiter.
+
+Thanks, and happy TDD-driven coding!


### PR DESCRIPTION
## Summary
- Demonstrates a small TDD cycle across three commits:
  1. add a failing test (infrastructure),
  2. implement a change to make the test pass,
  3. refactor and document for clarity.
- Adds a `Makefile` test target and a devcontainer feature used for the test.
- Updates `README.md` to emphasize Test-Driven Development and document how to run tests.

## Commits in this PR
(ordered oldest → newest; SHA, subject, files touched)

1. `992d252` — tdd: write a failing test  
   Files changed:
   - `.devcontainer/devcontainer.json`
   - `Makefile`
   Purpose:
   - Add test infrastructure used to demonstrate the TDD workflow.
   - `Makefile` includes a `test` target which invokes the typos checker used here as a small, fast verification step.
   - `devcontainer.json` lists features (make, typos) to ensure the dev environment can run the same test locally/CI.

2. `e0d9ca5` — tdd: make the test succeed  
   Files changed:
   - `README.md`
   Purpose:
   - Update project README to address the initial failing test. This demonstrates the TDD step "make the test pass" by changing implementation/documentation to satisfy the test condition.

3. `9d90a8a` — tdd: refactor  
   Files changed:
   - `README.md`
   Purpose:
   - Refactor and clarify README content (structure, TDD expectations, commands). This demonstrates the final TDD step: refactor while keeping tests passing.

## What changed (user-visible)
- A `Makefile` test target was added. Running `make test` will execute the small verification tool (typos).
- Devcontainer settings were added to make the test environment reproducible.
- `README.md` was rewritten to explicitly require TDD, list expectations and edge cases to test for, and show example commands for maintainers/candidates.

## How to verify locally
1. See the three commits and file changes:

```bash
git log -n 3 --pretty=format:'%h %ad %s' --date=iso
git show --name-only 992d252 e0d9ca5 9d90a8a
```

2. Run the test target (the command used in CI / dev flow):

```bash
make test
```

- This runs the `typos` check as defined in the `Makefile`. (It ran successfully in my session.)

3. Open the README to review the TDD guidance and commands:

```bash
less README.md
```

## Why this approach / rationale
- The sequence intentionally models TDD:
  - first commit adds a failing test (or test check),
  - second commit makes the test pass by changing the implementation/docs,
  - third commit refines and clarifies the change.
- Using a fast, deterministic check (typos) keeps the TDD cycle quick and reviewable while demonstrating the workflow. The README change documents expectations so reviewers and candidates can follow the same cycle.

## Notes for reviewers
- Confirm the `Makefile` and `devcontainer.json` align with your preferred test tooling. The current setup uses `typos` as a small demonstration check—if you'd prefer a different smoke test (lint, unit test runner), I can switch or add it.
- The README now puts TDD front-and-center. If you want stronger constraints (for example, mandatory commit messages that include `test:` or a specific test harness), I can update the README and add CI checks.
- If you'd like, I can:
  - Replace the typos check with a unit test example in a chosen framework (Jest/Vitest) and add package.json/scripts + a tiny test file.
  - Add a short CONTRIBUTING.md describing the commit pattern used here (test → implement → refactor).

## Summary / TL;DR
This PR shows a compact TDD example in three commits:
- added a failing test (infrastructure),
- made it pass by updating README,
- refactored/clarified README.  
Run `make test` to reproduce the check; review the three commits to see the test-first workflow.

If you want the PR description adjusted (shorter/longer) or to include actual diffs or screenshots, tell me which format you prefer and I’ll update it.
